### PR TITLE
Add MLOps Zoomcamp documentation section

### DIFF
--- a/courses/mlops-zoomcamp/certificate.md
+++ b/courses/mlops-zoomcamp/certificate.md
@@ -1,0 +1,32 @@
+---
+title: "Certificate"
+layout: default
+nav_order: 7
+parent: MLOps Zoomcamp
+has_children: false
+---
+
+# Certificate
+
+To earn the MLOps Zoomcamp certificate, complete the final project during a live cohort and pass peer review. For the cross-course rules (deadlines, peer review, and the minimum passing score), see [Certification]({{ '/courses/zoomcamp-logistics/certification/' | relative_url }}).
+
+## Getting your certificate
+
+Once you complete the project, the certificate appears in the [course management platform]({{ '/courses/course-management-platform/' | relative_url }}) on your dashboard.
+
+This does not happen automatically. After the project deadline and peer review, the course instructors still run some manual steps to issue the certificates. When the certificates are ready, there is an announcement in Slack and Telegram. Until that announcement, the certificate will not show up on your dashboard, even if your project is already finished.
+
+Once it is issued, a "Get certificate" button appears on your dashboard. The certificate is a PDF with a unique URL.
+
+## Adding your certificate to LinkedIn
+
+You can add the certificate to the "Licenses and Certifications" section of your LinkedIn profile:
+
+- Log in to your LinkedIn account, then go to your profile.
+- On the right, in the "Add profile section" dropdown, choose "Recommendations", then select "Licenses & Certifications".
+- In "Name", enter "MLOps Zoomcamp".
+- In "Issuing Organization", enter "DataTalksClub".
+- (Optional) In "Issue Date", enter the time when the certificate was created.
+- (Optional) Select the checkbox "This certification does not expire".
+- Put your certificate ID.
+- In "Certification URL", enter the URL for your certificate.

--- a/courses/mlops-zoomcamp/curriculum.md
+++ b/courses/mlops-zoomcamp/curriculum.md
@@ -1,0 +1,61 @@
+---
+title: "Curriculum"
+layout: default
+nav_order: 3
+parent: MLOps Zoomcamp
+has_children: false
+---
+
+# Curriculum
+
+The MLOps Zoomcamp covers six main modules plus a final project. Each module has video lectures, hands-on material, and a homework assignment.
+
+For the canonical curriculum (videos, code, exact homework questions), see the [GitHub repository](https://github.com/DataTalksClub/mlops-zoomcamp).
+
+## Modules
+
+[Module 1: Introduction](https://github.com/DataTalksClub/mlops-zoomcamp/tree/main/01-intro)
+
+- What is MLOps and why it matters.
+- MLOps maturity model.
+- The NY Taxi dataset used as the running example.
+- Course structure and environment setup.
+
+[Module 2: Experiment Tracking & Model Management](https://github.com/DataTalksClub/mlops-zoomcamp/tree/main/02-experiment-tracking)
+
+- Experiment tracking with MLflow.
+- Saving and loading models.
+- The model registry.
+
+[Module 3: Orchestration & ML Pipelines](https://github.com/DataTalksClub/mlops-zoomcamp/tree/main/03-orchestration)
+
+- Turning notebooks into orchestrated ML pipelines.
+- Workflow orchestration.
+
+[Module 4: Model Deployment](https://github.com/DataTalksClub/mlops-zoomcamp/tree/main/04-deployment)
+
+- Online vs. offline deployment.
+- Web service deployment with Flask.
+- Streaming deployment with AWS Kinesis and Lambda.
+- Batch scoring for offline processing.
+
+[Module 5: Model Monitoring](https://github.com/DataTalksClub/mlops-zoomcamp/tree/main/05-monitoring)
+
+- Monitoring ML services.
+- Web service monitoring with Prometheus, Evidently, and Grafana.
+- Batch job monitoring with Prefect, MongoDB, and Evidently.
+
+[Module 6: Best Practices](https://github.com/DataTalksClub/mlops-zoomcamp/tree/main/06-best-practices)
+
+- Unit and integration testing.
+- Linting, formatting, and pre-commit hooks.
+- CI/CD with GitHub Actions.
+- Infrastructure as Code with Terraform.
+
+[Final Project](https://github.com/DataTalksClub/mlops-zoomcamp/tree/main/07-project)
+
+- An end-to-end project that integrates experiment tracking, orchestration, deployment, and monitoring.
+
+## Homework and project
+
+Each module has a homework assignment. To earn the certificate, you also complete the final project during a live cohort. See [Project]({{ '/courses/mlops-zoomcamp/project/' | relative_url }}) for details.

--- a/courses/mlops-zoomcamp/environment-setup.md
+++ b/courses/mlops-zoomcamp/environment-setup.md
@@ -1,0 +1,50 @@
+---
+title: "Environment Setup"
+layout: default
+nav_order: 4
+parent: MLOps Zoomcamp
+has_children: false
+---
+
+# Environment Setup
+
+The MLOps Zoomcamp uses Python with common ML and MLOps tooling: MLflow, Prefect, Docker, Evidently, Grafana, Prometheus, Terraform, and AWS for cloud examples. This page covers the high-level setup decisions. For step-by-step setup, follow the videos in [Module 1](https://github.com/DataTalksClub/mlops-zoomcamp/tree/main/01-intro).
+
+## Where to run the course
+
+You can work locally or on a cloud VM. Module 1 demonstrates both:
+
+- A local machine with Python and Docker installed.
+- GitHub Codespaces.
+- A cloud VM (the course shows an AWS EC2 instance).
+
+A cloud VM is convenient because the later modules use AWS services anyway, and it keeps your environment consistent.
+
+## Python and dependency management
+
+The course uses Python with the scientific stack (pandas, scikit-learn) plus MLOps libraries. You can manage dependencies with `uv`, conda, or pip + venv. The choice does not affect the course content.
+
+On Windows, Anaconda is often the easiest way to get Python plus scientific libraries running. Docker Desktop covers the container side.
+
+## Docker
+
+Docker is used throughout the course for packaging models, running services, and reproducing environments. Install Docker and Docker Compose early. Module 1 includes the installation steps.
+
+## Cloud (AWS)
+
+The course uses AWS for several modules:
+
+- Module 4 deploys a streaming service with Kinesis and Lambda.
+- Module 6 provisions infrastructure with Terraform.
+
+New AWS accounts get free tier credits. You introduce each service as the modules reach it, so you do not need prior AWS experience.
+
+## Tools introduced per module
+
+- Module 2: MLflow.
+- Module 3: a workflow orchestrator.
+- Module 4: Flask, AWS Kinesis, AWS Lambda, Docker.
+- Module 5: Evidently, Grafana, Prometheus, Prefect, MongoDB.
+- Module 6: pytest, pre-commit, GitHub Actions, Terraform.
+
+Each module README lists exactly what to install for that module.

--- a/courses/mlops-zoomcamp/getting-started.md
+++ b/courses/mlops-zoomcamp/getting-started.md
@@ -26,6 +26,15 @@ After joining the [DataTalks.Club Slack workspace](https://datatalks.club/slack)
 
 Before asking questions, read [Asking Questions]({{ '/courses/zoomcamp-logistics/asking-questions/' | relative_url }}) and the [community guidelines](https://datatalks.club/slack/guidelines.html).
 
+## Follow the announcements
+
+So you don't miss anything:
+
+- Join the [course Telegram channel with announcements](https://t.me/dtc_courses).
+- Subscribe to the [DataTalks.Club YouTube channel](https://www.youtube.com/c/DataTalksClub) and check the [course playlist](https://www.youtube.com/playlist?list=PL3MmuxUbc_hIUISrluw_A7wDSmfOhErJK).
+
+Course announcements, including when certificates are ready, go out in Slack and Telegram.
+
 ## Watch the course videos
 
 All lectures are on the [course YouTube playlist](https://www.youtube.com/playlist?list=PL3MmuxUbc_hIUISrluw_A7wDSmfOhErJK). The repository README and each module folder link to the relevant videos in order.
@@ -42,3 +51,7 @@ Module 1 walks through environment setup, including Python, Docker, and an optio
 4. Complete the homework assignment.
 5. Check the cohort folder for cohort-specific materials and deadlines.
 6. Finish with the final project, which ties the modules together.
+
+## Getting your certificate
+
+Completing the final project during a live cohort earns you the certificate. See [Certificate]({{ '/courses/mlops-zoomcamp/certificate/' | relative_url }}) for how it is issued and how to add it to LinkedIn.

--- a/courses/mlops-zoomcamp/getting-started.md
+++ b/courses/mlops-zoomcamp/getting-started.md
@@ -1,0 +1,44 @@
+---
+title: "Getting Started"
+layout: default
+nav_order: 2
+parent: MLOps Zoomcamp
+has_children: false
+---
+
+# Getting Started
+
+For the cross-course onboarding, read [Joining a Cohort]({{ '/courses/zoomcamp-logistics/joining/' | relative_url }}) first. It covers registration, account setup, calendar, and newsletter updates.
+
+This page covers the MLOps Zoomcamp specifics.
+
+## Star the GitHub repository
+
+[github.com/DataTalksClub/mlops-zoomcamp](https://github.com/DataTalksClub/mlops-zoomcamp)
+
+Star it so you can find it later. All course materials are here, with each module having its own folder. Cohort-specific homework and deadlines are under the `cohorts/` folder.
+
+See [Resources]({{ '/courses/mlops-zoomcamp/resources/' | relative_url }}) for more.
+
+## Join the MLOps Zoomcamp Slack channel
+
+After joining the [DataTalks.Club Slack workspace](https://datatalks.club/slack), find the `#course-mlops-zoomcamp` channel. This is where questions, announcements, and discussion happen.
+
+Before asking questions, read [Asking Questions]({{ '/courses/zoomcamp-logistics/asking-questions/' | relative_url }}) and the [community guidelines](https://datatalks.club/slack/guidelines.html).
+
+## Watch the course videos
+
+All lectures are on the [course YouTube playlist](https://www.youtube.com/playlist?list=PL3MmuxUbc_hIUISrluw_A7wDSmfOhErJK). The repository README and each module folder link to the relevant videos in order.
+
+## Set up your environment
+
+Module 1 walks through environment setup, including Python, Docker, and an optional cloud VM. See [Environment Setup]({{ '/courses/mlops-zoomcamp/environment-setup/' | relative_url }}) for the high-level decisions before you start.
+
+## How to work through the course
+
+1. Start in the module folder you are working on.
+2. Read the README in that folder for an overview.
+3. Follow the links to the video lectures.
+4. Complete the homework assignment.
+5. Check the cohort folder for cohort-specific materials and deadlines.
+6. Finish with the final project, which ties the modules together.

--- a/courses/mlops-zoomcamp/index.md
+++ b/courses/mlops-zoomcamp/index.md
@@ -1,0 +1,27 @@
+---
+title: "MLOps Zoomcamp"
+layout: default
+nav_order: 5
+parent: Courses
+description: "Free, hands-on MLOps course on productionizing ML services"
+has_children: true
+---
+
+# MLOps Zoomcamp
+
+Welcome to the MLOps Zoomcamp. It is a completely free, hands-on course on productionizing machine learning services, from training and experimentation to deployment and monitoring.
+
+## Docs order
+
+Read in this order:
+
+1. [Community Guidelines]({{ '/general/guidelines/' | relative_url }}) - code of conduct, how to ask questions, how to use Slack channels, how to promote your work.
+2. [Zoomcamp Logistics]({{ '/courses/zoomcamp-logistics/' | relative_url }}) - how DataTalks.Club zoomcamps work in general (cohort schedule, joining, live sessions, homework, project, peer review, certification). Most of your logistical questions are answered there.
+3. The pages in this section - what is specific to the MLOps Zoomcamp (curriculum, environment, project, MLOps-specific resources).
+4. The [MLOps Zoomcamp FAQ](https://datatalks.club/faq/mlops-zoomcamp.html) - module-specific and technical questions from previous cohorts.
+
+For platform mechanics (where to click on the submission form, how the leaderboard appears), see [Course Management Platform]({{ '/courses/course-management-platform/' | relative_url }}).
+
+## Current status
+
+The MLOps Zoomcamp is currently available for self-paced study. We don't plan to run a live cohort in 2026. [Register here](https://airtable.com/shrCb8y6eTbPKwSTL) if you'd like to be notified in case we run it again.

--- a/courses/mlops-zoomcamp/prerequisites.md
+++ b/courses/mlops-zoomcamp/prerequisites.md
@@ -1,0 +1,35 @@
+---
+title: "Prerequisites"
+layout: default
+nav_order: 1
+parent: MLOps Zoomcamp
+has_children: false
+---
+
+# Prerequisites
+
+The MLOps Zoomcamp builds on existing machine learning and programming experience. It is not a beginner ML course; it teaches you how to take models you already know how to build and run them in production.
+
+For general expectations about zoomcamp time commitment, see [Before You Start]({{ '/courses/zoomcamp-logistics/before-you-start/' | relative_url }}).
+
+## Required skills
+
+You need these basics:
+
+- Python programming.
+- Comfort with the command line.
+- Docker basics.
+- Machine learning fundamentals: training a model, evaluating it, and understanding the typical ML workflow. The [Machine Learning Zoomcamp](https://github.com/DataTalksClub/machine-learning-zoomcamp) is a good way to cover this.
+- At least 1 year of programming experience.
+
+## You do not need
+
+You do not need these before starting:
+
+- Prior MLOps or DevOps experience. The course introduces experiment tracking, orchestration, deployment, and monitoring from the ground up.
+- Prior cloud experience. The course uses AWS but introduces the services it relies on.
+- Deep math. The focus is on engineering and operations, not modeling theory.
+
+## If you are missing a prerequisite
+
+If you are new to machine learning, take the [Machine Learning Zoomcamp](https://github.com/DataTalksClub/machine-learning-zoomcamp) first. If you are comfortable building models but new to Python tooling, Docker, or the command line, work through Module 1, which covers environment setup before the MLOps content begins.

--- a/courses/mlops-zoomcamp/project.md
+++ b/courses/mlops-zoomcamp/project.md
@@ -1,0 +1,37 @@
+---
+title: "Project"
+layout: default
+nav_order: 6
+parent: MLOps Zoomcamp
+has_children: false
+---
+
+# Project
+
+For the cross-course logistics, see [Final Project (Zoomcamp Logistics)]({{ '/courses/zoomcamp-logistics/project/' | relative_url }}). That page covers attempts, deadlines, peer review, and certification mechanics.
+
+This page covers what is specific to the MLOps Zoomcamp.
+
+## Goal
+
+The project is an end-to-end MLOps pipeline. You pick a problem and a dataset, train a model, and then apply the practices from the course to put it into production and operate it.
+
+## What the project should demonstrate
+
+A complete project applies the modules together:
+
+- A clear problem description.
+- Experiment tracking and a model registry (Module 2).
+- A training pipeline that can be run reproducibly (Module 3).
+- Model deployment, as a web service, streaming, or batch (Module 4).
+- Model monitoring (Module 5).
+- Best practices: tests, linting, CI/CD, and Infrastructure as Code where appropriate (Module 6).
+- Reproducibility: clear instructions and pinned dependencies so a reviewer can run it.
+
+## Where to find the details
+
+The [07-project folder](https://github.com/DataTalksClub/mlops-zoomcamp/tree/main/07-project) in the repository contains the project instructions and the evaluation criteria. The rubric there is the authoritative description of what is graded.
+
+## Certificate
+
+Completing the project during a live cohort is how you earn the certificate. Since there is no live 2026 cohort, the project is currently for self-assessment and portfolio building. See [Certification]({{ '/courses/zoomcamp-logistics/certification/' | relative_url }}) for how certification works in general.

--- a/courses/mlops-zoomcamp/project.md
+++ b/courses/mlops-zoomcamp/project.md
@@ -34,4 +34,4 @@ The [07-project folder](https://github.com/DataTalksClub/mlops-zoomcamp/tree/mai
 
 ## Certificate
 
-Completing the project during a live cohort is how you earn the certificate. Since there is no live 2026 cohort, the project is currently for self-assessment and portfolio building. See [Certification]({{ '/courses/zoomcamp-logistics/certification/' | relative_url }}) for how certification works in general.
+Completing the project during a live cohort is how you earn the certificate. Since there is no live 2026 cohort, the project is currently for self-assessment and portfolio building. See [Certificate]({{ '/courses/mlops-zoomcamp/certificate/' | relative_url }}) for how the certificate is issued and how to add it to LinkedIn, and [Certification]({{ '/courses/zoomcamp-logistics/certification/' | relative_url }}) for the cross-course rules.

--- a/courses/mlops-zoomcamp/resources.md
+++ b/courses/mlops-zoomcamp/resources.md
@@ -1,7 +1,7 @@
 ---
 title: "Resources"
 layout: default
-nav_order: 7
+nav_order: 8
 parent: MLOps Zoomcamp
 has_children: false
 ---

--- a/courses/mlops-zoomcamp/resources.md
+++ b/courses/mlops-zoomcamp/resources.md
@@ -1,0 +1,53 @@
+---
+title: "Resources"
+layout: default
+nav_order: 7
+parent: MLOps Zoomcamp
+has_children: false
+---
+
+# Resources
+
+Course-specific links for the MLOps Zoomcamp. For general zoomcamp logistics, see [Zoomcamp Logistics]({{ '/courses/zoomcamp-logistics/' | relative_url }}).
+
+## GitHub Repository
+
+The repository is your primary navigation tool throughout the course.
+
+[github.com/DataTalksClub/mlops-zoomcamp](https://github.com/DataTalksClub/mlops-zoomcamp)
+
+How to use it:
+
+1. Start in the module folder you are working on.
+2. Read the README in that folder for an overview.
+3. Follow the links to video lectures.
+4. Complete the homework assignment.
+5. Check the cohort folder for cohort-specific materials.
+
+## Video lectures
+
+All lectures are on the [course YouTube playlist](https://www.youtube.com/playlist?list=PL3MmuxUbc_hIUISrluw_A7wDSmfOhErJK).
+
+## FAQ
+
+The [MLOps Zoomcamp FAQ](https://datatalks.club/faq/mlops-zoomcamp.html) collects module-specific and technical questions from previous cohorts.
+
+## Slack
+
+Questions and discussion happen in the `#course-mlops-zoomcamp` channel on [DataTalks.Club Slack](https://datatalks.club/slack.html). Read [Asking Questions]({{ '/courses/zoomcamp-logistics/asking-questions/' | relative_url }}) first.
+
+## Tools used in the course
+
+- [MLflow](https://mlflow.org/) - experiment tracking and model registry.
+- [Prefect](https://www.prefect.io/) - workflow orchestration.
+- [Evidently](https://www.evidentlyai.com/) - data and model monitoring.
+- [Grafana](https://grafana.com/) and [Prometheus](https://prometheus.io/) - metrics and dashboards.
+- [Docker](https://www.docker.com/) - containerization.
+- [Terraform](https://www.terraform.io/) - Infrastructure as Code.
+- [AWS](https://aws.amazon.com/) - cloud deployment (Kinesis, Lambda).
+
+## Instructors
+
+- [Cristian Martinez](https://www.linkedin.com/in/cristian-javier-martinez-09bb7031/)
+- [Alexey Grigorev](https://www.linkedin.com/in/agrigorev/)
+- [Emeli Dral](https://www.linkedin.com/in/emelidral/)

--- a/courses/mlops-zoomcamp/whats-new.md
+++ b/courses/mlops-zoomcamp/whats-new.md
@@ -1,0 +1,19 @@
+---
+title: "What's New"
+layout: default
+nav_order: 5
+parent: MLOps Zoomcamp
+has_children: false
+---
+
+# Changes
+
+Notable points about the current state of the course.
+
+## Current status
+
+The MLOps Zoomcamp is in self-paced mode. We don't plan to run a live cohort in 2026. All materials remain freely available, and the GitHub repository is the source of truth for the latest content.
+
+For the canonical list of changes, follow the commit history and module READMEs in the [GitHub repository](https://github.com/DataTalksClub/mlops-zoomcamp). Materials from previous cohorts are preserved under the `cohorts/` folder.
+
+For the full curriculum, see [Curriculum]({{ '/courses/mlops-zoomcamp/curriculum/' | relative_url }}). For environment setup, see [Environment Setup]({{ '/courses/mlops-zoomcamp/environment-setup/' | relative_url }}).


### PR DESCRIPTION
Adds a course documentation section for the MLOps Zoomcamp under `courses/mlops-zoomcamp/`. Previously MLOps had no page of its own in the docs site; only the shared [zoomcamp-logistics](https://datatalks.club/docs/courses/zoomcamp-logistics/) pages covered it.

## Pages
Mirrors the ML Zoomcamp page set, adapted to MLOps:

- `index.md` - section landing + docs reading order
- `prerequisites.md` - required/not-required skills
- `getting-started.md` - repo, Slack, announcements (Telegram/YouTube), how to work through the course, link to the certificate page. Absorbs the old repo `after-sign-up.md` content.
- `curriculum.md` - the six modules + final project
- `environment-setup.md` - Python, Docker, AWS, tools per module
- `whats-new.md` - current status (self-paced, no 2026 cohort)
- `project.md` - what the end-to-end project should demonstrate
- `certificate.md` - certificate appears on the course platform after grading, issued manually by instructors, announced in Slack/Telegram, plus LinkedIn instructions. Replaces the repo `certificate.md`.
- `resources.md` - repo, playlist, FAQ, Slack, tools, instructors

## Notes
- Paired with mlops-zoomcamp PR #398 (README unification + moving certificate/after-sign-up content here).
- `nav_order: 5` slots MLOps after LLM, avoiding renumbering other course indexes. Easy to reorder.
- Follows the repo style rules (no tables, no bold, spaces around dashes, internal links via `relative_url`).
- Only new/edited MLOps pages in this PR; unrelated working-tree changes were left untouched.